### PR TITLE
Multiplex_infomap patch

### DIFF
--- a/server.R
+++ b/server.R
@@ -2596,7 +2596,6 @@ shinyServer(function(input, output, session) {
                             exeFlags <- paste("-s", floor(runif(1)*1e7), 
                                                           "-N", as.numeric(input$txtMultimapTries),
                                                           "-multiplex -physical -smartinit",
-                                                          "-switchrate", as.numeric(input$txtMultimapRelaxRate),
                                                           inputFile)
                         }                        
 


### PR DESCRIPTION
This fixes the multiplex_infomap error for community detection on networks which are not edge-coloured. The error was centered on the relax rate being set. A detailed description can be found in the forum here: https://groups.google.com/forum/#!category-topic/muxviz/mac-os-x-usage/4Nf2kcRfcWA